### PR TITLE
reduce nbPoints to fit baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "rollup": "^1.31.0"
   },
   "dependencies": {
-    "ml-regression-polynomial": "^2.1.0"
+    "ml-regression-polynomial": "^2.1.0",
+    "ml-spectra-processing": "^1.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import PolynomialRegression from 'ml-regression-polynomial';
+import { XY } from 'ml-spectra-processing';
 
 /**
  * Iterative regression-based baseline correction
@@ -9,6 +10,8 @@ import PolynomialRegression from 'ml-regression-polynomial';
  * @param {function} [options.Regression = PolynomialRegression] - Regression class with a predict method
  * @param {*} [options.regressionOptions] - Options for regressionFunction
  * @param {number} [options.tolerance = 0.001] - Convergence error tolerance
+ * @param {boolean} [options.reduce = true] - If true, the number of points is reduced to options.nbPoints to performes baseline fitting
+ * @param {number} [options.nbPoints = 4001] - Number of points of data input for baseline fitting if options.reduce is true.
  * @return {{corrected: Array<number>, delta: number, iteration: number, baseline: Array<number>}}
  */
 export default function baselineCorrectionRegression(x, y, options = {}) {
@@ -17,24 +20,36 @@ export default function baselineCorrectionRegression(x, y, options = {}) {
     Regression = PolynomialRegression,
     regressionOptions,
     tolerance = 0.001,
+    reduce = true,
+    nbPoints = 4001,
   } = options;
 
   if (!regressionOptions && Regression === PolynomialRegression) {
     regressionOptions = 3;
   }
 
-  let baseline = y.slice();
-  let fitting = y.slice();
-  let oldFitting = y;
+  let xTemp, yTemp;
+  if (reduce) {
+    let reducedData = XY.reduce(x, y, { nbPoints });
+    yTemp = reducedData.y;
+    xTemp = reducedData.x;
+  } else {
+    xTemp = x.slice();
+    yTemp = y.slice();
+  }
+
+  let baseline = yTemp.slice();
+  let fitting = yTemp.slice();
+  let oldFitting = yTemp.slice();
   let iteration = 0;
-  let delta;
+  let delta, regression;
   while (iteration < maxIterations) {
     // Calculate the fitting result
-    let regression = new Regression(x, baseline, regressionOptions);
+    regression = new Regression(xTemp, baseline, regressionOptions);
 
     delta = 0;
     for (let i = 0; i < baseline.length; i++) {
-      fitting[i] = regression.predict(x[i]);
+      fitting[i] = regression.predict(xTemp[i]);
       if (baseline[i] > fitting[i]) {
         baseline[i] = fitting[i];
       }
@@ -52,10 +67,9 @@ export default function baselineCorrectionRegression(x, y, options = {}) {
   }
 
   // removes baseline
-  let corrected = new Array(baseline.length);
-  for (let j = 0; j < baseline.length; j++) {
-    corrected[j] = y[j] - baseline[j];
-  }
+  if (reduce) baseline = x.map((e) => regression.predict(e));
+
+  let corrected = baseline.map((e, i) => y[i] - e);
 
   return { corrected, delta, iteration, baseline };
 }


### PR DESCRIPTION
When the input signal has a lot of points (>=8K) the baseline correction goes slow. The idea comes from the baseline shape is not affected by a reduction of the number of points and the algorithm performs the regression faster because of the matrix size is reduced.

There is just one question,
Can I move the reducer from spectra-processing?